### PR TITLE
Color distance now uses euclidean distance and huge speed up in drawing

### DIFF
--- a/src/easel.rs
+++ b/src/easel.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use std::thread;
 use self::failure::Error;
 use self::enigo::{Enigo, MouseButton, MouseControllable};
-use std::i16;
+use std::f32;
 
 pub type Point = (i32, i32);
 
@@ -128,22 +128,23 @@ impl Color {
             Color::Violet,
             Color::LightViolet,
         ];
-        let r = i16::from(color.0);
-        let g = i16::from(color.1);
-        let b = i16::from(color.2);
+        let r = f32::from(color.0);
+        let g = f32::from(color.1);
+        let b = f32::from(color.2);
 
         let mut closest = Color::Black;
-        let mut color_dist = i16::MAX;
+        let mut color_dist = f32::MAX;
 
         // Iterate over all colors and compare the RBG values to find the
         // closest value to the input color.
         for col in colors {
             let hex = col.get_hex();
-            let col_r = i16::from(hex.0);
-            let col_g = i16::from(hex.1);
-            let col_b = i16::from(hex.2);
-            let curr_color_dist =
-                (col_r - r).abs() + (col_g - g).abs() + (col_b - b).abs();
+            let col_r = f32::from(hex.0);
+            let col_g = f32::from(hex.1);
+            let col_b = f32::from(hex.2);
+            let curr_color_dist = ((col_r - r).powi(2) + (col_g - g).powi(2)
+                + (col_b - b).powi(2))
+                .sqrt();
             if curr_color_dist < color_dist {
                 closest = col;
                 color_dist = curr_color_dist;

--- a/src/image_trans.rs
+++ b/src/image_trans.rs
@@ -16,11 +16,13 @@ pub fn draw_image(
 ) -> Result<(), Error> {
     let mut easel = Easel::new(easel_config)?;
     let mut image = image::open(image_path)?.to_rgb();
-    easel.change_brush_size(0, enigo, wait_time);
+    let brush_wait = Duration::from_millis(32);
+    easel.change_brush_size(0, enigo, &brush_wait);
     let (size_x, size_y) = image.dimensions();
 
-    if (size_x > size_y && easel.orientation == Orientation::Portrait) || 
-        (size_y > size_x && easel.orientation == Orientation::Landscape) {
+    if (size_x > size_y && easel.orientation == Orientation::Portrait)
+        || (size_y > size_x && easel.orientation == Orientation::Landscape)
+    {
         easel.change_orientation(enigo, wait_time);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,16 @@ use std::thread;
 use std::process;
 use sdl2::keyboard::Keycode;
 use sdl2::event::Event;
+use std::u64;
 
 fn main() {
     thread::spawn(move || {
         let sdl_context = sdl2::init().unwrap();
         let video_subsystem = sdl_context.video().unwrap();
-        let _window =
-            video_subsystem.window("Passpartout Printer", 1920, 1200).build().unwrap();
+        let _window = video_subsystem
+            .window("Passpartout Printer", 1920, 1200)
+            .build()
+            .unwrap();
         let mut event_pump = sdl_context.event_pump().unwrap();
         loop {
             for event in event_pump.poll_iter() {
@@ -40,9 +43,11 @@ fn main() {
 
     let draw_thread = thread::spawn(move || {
         let picture: String = env::args().nth(1).unwrap();
-        // Assume that the game runs at 60Hz, we should refresh every 16ms. Hence,
-        // let's wait two frames during each operation.
-        let wait_time = Duration::from_millis(32);
+        let duration: u64 = match env::args().nth(2) {
+            Some(v) => v.parse().unwrap(),
+            None => 10_u64,
+        };
+        let wait_time = Duration::from_millis(duration);
         let mut enigo = Enigo::new();
         image_trans::draw_image(
             &picture,


### PR DESCRIPTION
- to try to get closer colors, we use euclidean distance
- the frame rate is much higher than previously thought, can draw at
  6-7ms per operation instead of 32ms per operation
- decreasing the size of the brush can't keep up at higher speeds, so
  that is set to 32ms
- duration between operations is now an optional input parameter